### PR TITLE
feat: 유저 상세, 유저 정보 변경 API 구현 및 점심추천기능 테이블 분리

### DIFF
--- a/src/main/java/com/foodiefinder/user/controller/UserController.java
+++ b/src/main/java/com/foodiefinder/user/controller/UserController.java
@@ -1,15 +1,13 @@
 package com.foodiefinder.user.controller;
 
 
+import com.foodiefinder.user.dto.UserDetailResponse;
 import com.foodiefinder.user.dto.UserSignupRequest;
 import com.foodiefinder.user.service.UserService;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
-import org.springframework.web.bind.annotation.PostMapping;
-import org.springframework.web.bind.annotation.RequestBody;
-import org.springframework.web.bind.annotation.RequestMapping;
-import org.springframework.web.bind.annotation.RestController;
+import org.springframework.web.bind.annotation.*;
 
 import java.net.URI;
 
@@ -26,6 +24,14 @@ public class UserController {
         Long userId = userService.saveUser(request);
 
         return ResponseEntity.created(URI.create("/api/users/signup/" + userId)).build();
+    }
+
+    @GetMapping("/{userId}")
+    public ResponseEntity<?> userDetail(@PathVariable Long userId) {
+
+        UserDetailResponse response = userService.getUserDetail(userId);
+
+        return ResponseEntity.ok(response);
     }
 }
 

--- a/src/main/java/com/foodiefinder/user/controller/UserController.java
+++ b/src/main/java/com/foodiefinder/user/controller/UserController.java
@@ -2,6 +2,7 @@ package com.foodiefinder.user.controller;
 
 
 import com.foodiefinder.user.dto.UserDetailResponse;
+import com.foodiefinder.user.dto.UserInfoUpdateRequest;
 import com.foodiefinder.user.dto.UserSignupRequest;
 import com.foodiefinder.user.service.UserService;
 import jakarta.validation.Valid;
@@ -32,6 +33,15 @@ public class UserController {
         UserDetailResponse response = userService.getUserDetail(userId);
 
         return ResponseEntity.ok(response);
+    }
+
+    @PatchMapping("/{userId}")
+    public ResponseEntity<?> userInfoUpdate(@PathVariable Long userId,
+                                            @RequestBody UserInfoUpdateRequest request) {
+
+        userService.infoUpdate(userId, request);
+
+        return ResponseEntity.noContent().build();
     }
 }
 

--- a/src/main/java/com/foodiefinder/user/dto/UserDetailResponse.java
+++ b/src/main/java/com/foodiefinder/user/dto/UserDetailResponse.java
@@ -1,0 +1,25 @@
+package com.foodiefinder.user.dto;
+
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@NoArgsConstructor
+public class UserDetailResponse {
+
+    private Long id;
+    private String account;
+    private String latitude;
+    private String longitude;
+    private boolean lunchRecommendationEnabled;
+
+    @Builder
+    public UserDetailResponse(Long id, String account, String latitude, String longitude, boolean lunchRecommendationEnabled) {
+        this.id = id;
+        this.account = account;
+        this.latitude = latitude;
+        this.longitude = longitude;
+        this.lunchRecommendationEnabled = lunchRecommendationEnabled;
+    }
+}

--- a/src/main/java/com/foodiefinder/user/dto/UserInfoUpdateRequest.java
+++ b/src/main/java/com/foodiefinder/user/dto/UserInfoUpdateRequest.java
@@ -1,0 +1,11 @@
+package com.foodiefinder.user.dto;
+
+import lombok.Getter;
+
+@Getter
+public class UserInfoUpdateRequest {
+
+    private String latitude;
+    private String longitude;
+    private boolean lunchRecommendationEnabled;
+}

--- a/src/main/java/com/foodiefinder/user/dto/UserInfoUpdateRequest.java
+++ b/src/main/java/com/foodiefinder/user/dto/UserInfoUpdateRequest.java
@@ -1,11 +1,21 @@
 package com.foodiefinder.user.dto;
 
+import lombok.Builder;
 import lombok.Getter;
+import lombok.NoArgsConstructor;
 
 @Getter
+@NoArgsConstructor
 public class UserInfoUpdateRequest {
 
     private String latitude;
     private String longitude;
     private boolean lunchRecommendationEnabled;
+
+    @Builder
+    public UserInfoUpdateRequest(String latitude, String longitude, boolean lunchRecommendationEnabled) {
+        this.latitude = latitude;
+        this.longitude = longitude;
+        this.lunchRecommendationEnabled = lunchRecommendationEnabled;
+    }
 }

--- a/src/main/java/com/foodiefinder/user/entity/LunchRecommendationSettings.java
+++ b/src/main/java/com/foodiefinder/user/entity/LunchRecommendationSettings.java
@@ -1,0 +1,35 @@
+package com.foodiefinder.user.entity;
+
+import jakarta.persistence.*;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Entity
+@Getter
+@NoArgsConstructor
+public class LunchRecommendationSettings {
+
+    @Id @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    private boolean lunchRecommendationEnabled;
+
+    @OneToOne(fetch = FetchType.LAZY)
+    private User user;
+
+
+
+    @Builder
+    public LunchRecommendationSettings(boolean lunchRecommendationEnabled, User user) {
+        this.lunchRecommendationEnabled = lunchRecommendationEnabled;
+        this.user = user;
+    }
+
+    public void infoUpdate(boolean lunchRecommendationEnabled) {
+        this.lunchRecommendationEnabled = lunchRecommendationEnabled != false ?
+                lunchRecommendationEnabled : this.lunchRecommendationEnabled;
+    }
+
+
+}

--- a/src/main/java/com/foodiefinder/user/entity/User.java
+++ b/src/main/java/com/foodiefinder/user/entity/User.java
@@ -29,20 +29,15 @@ public class User extends BaseTimeEntity {
     //경도
     private String longitude;
 
-    //점심추천기능 사용 여부
-    private boolean lunchRecommendationEnabled;
-
     @Builder
     public User(String account, String password) {
         this.account = account;
         this.password = password;
     }
 
-    public void userInfoUpdate(String latitude, String longitude, boolean lunchRecommendationEnabled) {
+    public void userInfoUpdate(String latitude, String longitude) {
         this.latitude = latitude != null ? latitude : this.latitude;
-        this.longitude = longitude != null ? longitude : this.latitude;
-        this.lunchRecommendationEnabled = lunchRecommendationEnabled != false ?
-                lunchRecommendationEnabled : this.lunchRecommendationEnabled;
+        this.longitude = longitude != null ? longitude : this.longitude;
     }
 
 

--- a/src/main/java/com/foodiefinder/user/entity/User.java
+++ b/src/main/java/com/foodiefinder/user/entity/User.java
@@ -38,5 +38,13 @@ public class User extends BaseTimeEntity {
         this.password = password;
     }
 
+    public void userInfoUpdate(String latitude, String longitude, boolean lunchRecommendationEnabled) {
+        this.latitude = latitude != null ? latitude : this.latitude;
+        this.longitude = longitude != null ? longitude : this.latitude;
+        this.lunchRecommendationEnabled = lunchRecommendationEnabled != false ?
+                lunchRecommendationEnabled : this.lunchRecommendationEnabled;
+    }
+
+
 
 }

--- a/src/main/java/com/foodiefinder/user/repository/LunchRecommendationSettingsRepository.java
+++ b/src/main/java/com/foodiefinder/user/repository/LunchRecommendationSettingsRepository.java
@@ -1,0 +1,12 @@
+package com.foodiefinder.user.repository;
+
+import com.foodiefinder.user.entity.LunchRecommendationSettings;
+import com.foodiefinder.user.entity.User;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import java.util.Optional;
+
+public interface LunchRecommendationSettingsRepository extends JpaRepository<LunchRecommendationSettings, Long> {
+
+    Optional<LunchRecommendationSettings> findByUser(User user);
+}

--- a/src/main/java/com/foodiefinder/user/service/UserService.java
+++ b/src/main/java/com/foodiefinder/user/service/UserService.java
@@ -4,6 +4,7 @@ import com.foodiefinder.common.exception.CustomException;
 import com.foodiefinder.common.exception.ErrorCode;
 import com.foodiefinder.user.crypto.PasswordEncoder;
 import com.foodiefinder.user.dto.UserDetailResponse;
+import com.foodiefinder.user.dto.UserInfoUpdateRequest;
 import com.foodiefinder.user.dto.UserSignupRequest;
 import com.foodiefinder.user.entity.User;
 import com.foodiefinder.user.repository.UserRepository;
@@ -56,5 +57,14 @@ public class UserService {
                 .build();
 
         return response;
+    }
+
+    @Transactional
+    public void infoUpdate(Long userId, UserInfoUpdateRequest request) {
+        User user = userRepository.findById(userId)
+                .orElseThrow(() -> new CustomException(ErrorCode.USER_NOT_FOUND));
+
+        user.userInfoUpdate(request.getLatitude(),
+                request.getLongitude(), request.isLunchRecommendationEnabled());
     }
 }

--- a/src/main/java/com/foodiefinder/user/service/UserService.java
+++ b/src/main/java/com/foodiefinder/user/service/UserService.java
@@ -3,6 +3,7 @@ package com.foodiefinder.user.service;
 import com.foodiefinder.common.exception.CustomException;
 import com.foodiefinder.common.exception.ErrorCode;
 import com.foodiefinder.user.crypto.PasswordEncoder;
+import com.foodiefinder.user.dto.UserDetailResponse;
 import com.foodiefinder.user.dto.UserSignupRequest;
 import com.foodiefinder.user.entity.User;
 import com.foodiefinder.user.repository.UserRepository;
@@ -40,5 +41,20 @@ public class UserService {
                 .ifPresent(user -> {
                     throw new CustomException(ErrorCode.USER_ALREADY_EXIST);
                 });
+    }
+
+    public UserDetailResponse getUserDetail(Long userId) {
+        User user = userRepository.findById(userId)
+                .orElseThrow(() -> new CustomException(ErrorCode.USER_NOT_FOUND));
+
+        UserDetailResponse response = UserDetailResponse.builder()
+                .id(user.getId())
+                .account(user.getAccount())
+                .latitude(user.getLatitude())
+                .longitude(user.getLongitude())
+                .lunchRecommendationEnabled(user.isLunchRecommendationEnabled())
+                .build();
+
+        return response;
     }
 }

--- a/src/test/java/com/foodiefinder/user/controller/UserControllerTest.java
+++ b/src/test/java/com/foodiefinder/user/controller/UserControllerTest.java
@@ -6,6 +6,7 @@ import com.foodiefinder.auth.jwt.JwtUtils;
 import com.foodiefinder.common.exception.CustomException;
 import com.foodiefinder.common.exception.ErrorCode;
 import com.foodiefinder.user.dto.UserDetailResponse;
+import com.foodiefinder.user.dto.UserInfoUpdateRequest;
 import com.foodiefinder.user.dto.UserSignupRequest;
 import com.foodiefinder.user.repository.UserRepository;
 import com.foodiefinder.user.service.UserService;
@@ -122,5 +123,24 @@ class UserControllerTest {
 
     }
 
+    @DisplayName("유저 정보 업데이트")
+    @WithMockUser
+    @Test
+    void userInfoUpdate() throws Exception {
+        UserInfoUpdateRequest request = UserInfoUpdateRequest.builder()
+                .latitude("123")
+                .longitude("456")
+                .lunchRecommendationEnabled(true)
+                .build();
+
+        Long userId = 1L;
+        String json = objectMapper.writeValueAsString(request);
+
+        mockMvc.perform(patch("/api/users/" + userId).with(csrf())
+                .contentType(APPLICATION_JSON)
+                .content(json))
+                .andExpect(status().isNoContent())
+                .andDo(print());
+    }
 
 }

--- a/src/test/java/com/foodiefinder/user/controller/UserControllerTest.java
+++ b/src/test/java/com/foodiefinder/user/controller/UserControllerTest.java
@@ -1,11 +1,11 @@
 package com.foodiefinder.user.controller;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
-import com.foodiefinder.auth.config.SecurityConfig;
 import com.foodiefinder.auth.filter.JwtAuthenticationFilter;
 import com.foodiefinder.auth.jwt.JwtUtils;
 import com.foodiefinder.common.exception.CustomException;
 import com.foodiefinder.common.exception.ErrorCode;
+import com.foodiefinder.user.dto.UserDetailResponse;
 import com.foodiefinder.user.dto.UserSignupRequest;
 import com.foodiefinder.user.repository.UserRepository;
 import com.foodiefinder.user.service.UserService;
@@ -26,7 +26,7 @@ import static org.springframework.http.MediaType.*;
 import static org.springframework.security.test.web.servlet.request.SecurityMockMvcRequestPostProcessors.csrf;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.*;
 import static org.springframework.test.web.servlet.result.MockMvcResultHandlers.print;
-import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.*;
 
 @WebMvcTest(controllers = UserController.class,
         excludeFilters = {
@@ -93,9 +93,34 @@ class UserControllerTest {
         verify(userService).saveUser(any());
     }
 
+    @DisplayName("유저 상세 조회")
+    @WithMockUser
+    @Test
+    void userDetail() throws Exception {
 
+        UserDetailResponse response = UserDetailResponse.builder()
+                .id(1L)
+                .account("testAccount")
+                .latitude("123")
+                .longitude("456")
+                .lunchRecommendationEnabled(false)
+                .build();
 
+        given(userService.getUserDetail(1L)).willReturn(response);
 
+        mockMvc.perform(get("/api/users/1")
+                .contentType(APPLICATION_JSON))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.id").value(1L))
+                .andExpect(jsonPath("$.account").value("testAccount"))
+                .andExpect(jsonPath("$.latitude").value("123"))
+                .andExpect(jsonPath("$.longitude").value("456"))
+                .andExpect(jsonPath("$.lunchRecommendationEnabled").value("false"))
+                .andDo(print());
+
+        verify(userService, times(1)).getUserDetail(1L);
+
+    }
 
 
 }

--- a/src/test/java/com/foodiefinder/user/service/UserServiceTest.java
+++ b/src/test/java/com/foodiefinder/user/service/UserServiceTest.java
@@ -4,6 +4,7 @@ import com.foodiefinder.common.exception.CustomException;
 import com.foodiefinder.common.exception.ErrorCode;
 import com.foodiefinder.user.crypto.PasswordEncoder;
 import com.foodiefinder.user.dto.UserDetailResponse;
+import com.foodiefinder.user.dto.UserInfoUpdateRequest;
 import com.foodiefinder.user.dto.UserSignupRequest;
 import com.foodiefinder.user.entity.User;
 import com.foodiefinder.user.repository.UserRepository;
@@ -102,6 +103,36 @@ class UserServiceTest {
         assertEquals(user.getLatitude(), response.getLatitude());
         assertEquals(user.getLongitude(), response.getLongitude());
         assertEquals(user.isLunchRecommendationEnabled(), response.isLunchRecommendationEnabled());
+
+    }
+
+    @DisplayName("유저 정보 업데이트")
+    @Test
+    void userInfoUpdate() throws Exception {
+        User user = User.builder()
+                .account("testAccount")
+                .password("123123qwe!!")
+                .build();
+
+        Long userId = user.getId();
+
+        UserInfoUpdateRequest request = UserInfoUpdateRequest.builder()
+                .latitude("123")
+                .longitude("456")
+                .lunchRecommendationEnabled(true)
+                .build();
+
+        given(userRepository.findById(userId)).willReturn(Optional.of(user));
+
+        userService.infoUpdate(user.getId(), request);
+
+        assertEquals(user.getLatitude(), request.getLatitude());
+        assertEquals(user.getLongitude(), request.getLongitude());
+        assertEquals(user.isLunchRecommendationEnabled(), request.isLunchRecommendationEnabled());
+
+
+
+
     }
 
 

--- a/src/test/java/com/foodiefinder/user/service/UserServiceTest.java
+++ b/src/test/java/com/foodiefinder/user/service/UserServiceTest.java
@@ -6,7 +6,9 @@ import com.foodiefinder.user.crypto.PasswordEncoder;
 import com.foodiefinder.user.dto.UserDetailResponse;
 import com.foodiefinder.user.dto.UserInfoUpdateRequest;
 import com.foodiefinder.user.dto.UserSignupRequest;
+import com.foodiefinder.user.entity.LunchRecommendationSettings;
 import com.foodiefinder.user.entity.User;
+import com.foodiefinder.user.repository.LunchRecommendationSettingsRepository;
 import com.foodiefinder.user.repository.UserRepository;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
@@ -31,6 +33,9 @@ class UserServiceTest {
 
     @Mock
     private UserRepository userRepository;
+
+    @Mock
+    private LunchRecommendationSettingsRepository lunchRecommendationSettingsRepository;
 
     @Spy
     private PasswordEncoder passwordEncoder;
@@ -92,9 +97,15 @@ class UserServiceTest {
 
         userRepository.save(user);
 
+        LunchRecommendationSettings settings = LunchRecommendationSettings.builder()
+                .user(user)
+                .lunchRecommendationEnabled(true)
+                .build();
+
         Long userId = user.getId();
 
         given(userRepository.findById(userId)).willReturn(Optional.of(user));
+        given(lunchRecommendationSettingsRepository.findByUser(user)).willReturn(Optional.of(settings));
 
         UserDetailResponse response = userService.getUserDetail(userId);
 
@@ -102,7 +113,7 @@ class UserServiceTest {
         assertEquals(user.getAccount(), response.getAccount());
         assertEquals(user.getLatitude(), response.getLatitude());
         assertEquals(user.getLongitude(), response.getLongitude());
-        assertEquals(user.isLunchRecommendationEnabled(), response.isLunchRecommendationEnabled());
+
 
     }
 
@@ -122,13 +133,18 @@ class UserServiceTest {
                 .lunchRecommendationEnabled(true)
                 .build();
 
+        LunchRecommendationSettings settings = LunchRecommendationSettings.builder()
+                .user(user)
+                .lunchRecommendationEnabled(true)
+                .build();
+
         given(userRepository.findById(userId)).willReturn(Optional.of(user));
+        given(lunchRecommendationSettingsRepository.findByUser(user)).willReturn(Optional.of(settings));
 
         userService.infoUpdate(user.getId(), request);
 
         assertEquals(user.getLatitude(), request.getLatitude());
         assertEquals(user.getLongitude(), request.getLongitude());
-        assertEquals(user.isLunchRecommendationEnabled(), request.isLunchRecommendationEnabled());
 
 
 

--- a/src/test/java/com/foodiefinder/user/service/UserServiceTest.java
+++ b/src/test/java/com/foodiefinder/user/service/UserServiceTest.java
@@ -3,10 +3,10 @@ package com.foodiefinder.user.service;
 import com.foodiefinder.common.exception.CustomException;
 import com.foodiefinder.common.exception.ErrorCode;
 import com.foodiefinder.user.crypto.PasswordEncoder;
+import com.foodiefinder.user.dto.UserDetailResponse;
 import com.foodiefinder.user.dto.UserSignupRequest;
 import com.foodiefinder.user.entity.User;
 import com.foodiefinder.user.repository.UserRepository;
-import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
@@ -14,7 +14,7 @@ import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.Spy;
 import org.mockito.junit.jupiter.MockitoExtension;
-
+import java.util.Optional;
 
 import static org.junit.jupiter.api.Assertions.*;
 import static org.mockito.ArgumentMatchers.any;
@@ -79,5 +79,30 @@ class UserServiceTest {
         verify(userRepository, times(0)).save(any(User.class));
 
     }
+
+    @DisplayName("회원 상세 조회")
+    @Test
+    void userDetail() throws Exception {
+
+        User user = User.builder()
+                .account("testAccount")
+                .password("123123qwe!!")
+                .build();
+
+        userRepository.save(user);
+
+        Long userId = user.getId();
+
+        given(userRepository.findById(userId)).willReturn(Optional.of(user));
+
+        UserDetailResponse response = userService.getUserDetail(userId);
+
+        assertEquals(userId, response.getId());
+        assertEquals(user.getAccount(), response.getAccount());
+        assertEquals(user.getLatitude(), response.getLatitude());
+        assertEquals(user.getLongitude(), response.getLongitude());
+        assertEquals(user.isLunchRecommendationEnabled(), response.isLunchRecommendationEnabled());
+    }
+
 
 }


### PR DESCRIPTION
## 🚀 풀 리퀘스트 요약

우선, `점심추천기능`을 분리하였습니다. 
회원가입 진행시 해당 유저의 점심추천기능 테이블의 알림설정을 `false`로 설정하여 저장합니다.
`회원상세API`에서는 기존 회원의 `계정, 위도, 경도`를 수집하고, 별도로 점심추천기능 테이블의 해당 유저의 점심추천 필드를 가져옵니다.
`회원 정보 수정`에서는 회원 테이블의 정보와 점심추천기능 테이블의 정보를 별도 수정합니다.

## 📋 변경 사항

- [x] 새로운 기능 추가
- [ ] 버그 수정
- [ ] 코드에 영향을 주지 않는 변경사항(오타 수정, 탭 사이즈 변경, 변수명 변경 등)
- [x] 코드 리팩토링
- [ ] 주석 추가 및 수정
- [ ] 문서 수정
- [x] 테스트 추가, 테스트 리팩토링
- [ ] 빌드 부분 혹은 패키지 매니저 수정
- [ ] 파일 혹은 폴더명 수정
- [ ] 파일 혹은 폴더 삭제

## 📸 스크린샷

(선택 사항: 변경된 내용을 시각적으로 보여주기 위해 스크린샷을 첨부하세요.)

## 📌 체크리스트

- [x] 커밋 메시지 컨벤션에 맞게 작성했습니다.
- [x] 모든 테스트를 통과합니다.

## 📎 관련 이슈

#47 #50 

## 🙌 리뷰 및 피드백

(리뷰어들께 질문하거나 특정 리뷰를 요청하는 내용을 작성하세요.)
