### PR TITLE
feat: refresh토큰 발급 추가 및 액세스토큰 재발급 api 구현

### DIFF
--- a/src/main/java/com/foodiefinder/auth/config/SecurityConfig.java
+++ b/src/main/java/com/foodiefinder/auth/config/SecurityConfig.java
@@ -31,6 +31,7 @@ public class SecurityConfig {
                 .authorizeHttpRequests(request -> request
                     .requestMatchers(HttpMethod.POST, "/api/users/signup").permitAll()
                     .requestMatchers(HttpMethod.POST, "/api/users/login").permitAll()
+                    .requestMatchers(HttpMethod.POST, "/api/users/refresh").permitAll()
                 .anyRequest().authenticated()
                 )
                 //csrf(사이즈간 위조 요청) 설정 꺼놈 ->rest api는 stateless하기 떄문에 인증정보를 보관하지 않기 때문- token방식 사용

--- a/src/main/java/com/foodiefinder/auth/controller/AuthController.java
+++ b/src/main/java/com/foodiefinder/auth/controller/AuthController.java
@@ -2,9 +2,11 @@ package com.foodiefinder.auth.controller;
 
 import com.foodiefinder.auth.dto.UserLoginRequest;
 import com.foodiefinder.auth.service.AuthService;
+import jakarta.servlet.http.Cookie;
 import jakarta.validation.Valid;
 import lombok.Getter;
 import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseCookie;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.core.Authentication;
 import org.springframework.web.bind.annotation.*;
@@ -22,10 +24,27 @@ public class AuthController {
     @PostMapping("/login")
     public ResponseEntity<?> login(@Valid @RequestBody UserLoginRequest request) {
 
-        String token = authService.login(request);
+        String[] tokens = authService.login(request);
 
         Map<String, String> response = new HashMap<>();
-        response.put("token", token);
+        response.put("Bearer", tokens[0]);
+
+        ResponseCookie refreshToken = ResponseCookie.from("Bearer", tokens[1])
+                .httpOnly(true)
+                .path("/")
+                .maxAge(24 * 60 * 60)
+                .secure(true)
+                .build();
+
+        return ResponseEntity.ok().header("Set-Cookie", refreshToken.toString()).body(response);
+    }
+
+    @PostMapping("/refresh")
+    public ResponseEntity<?> refresh(@CookieValue("Bearer") String refreshToken) {
+        String newAccessToken = authService.issueRefreshToken(refreshToken);
+
+        Map<String, String> response = new HashMap<>();
+        response.put("Bearer", newAccessToken);
 
         return ResponseEntity.ok().body(response);
     }

--- a/src/main/java/com/foodiefinder/auth/service/AuthService.java
+++ b/src/main/java/com/foodiefinder/auth/service/AuthService.java
@@ -17,7 +17,7 @@ public class AuthService {
     private final PasswordEncoder passwordEncoder;
     private final JwtUtils jwtUtils;
 
-    public String login(UserLoginRequest request) {
+    public String[] login(UserLoginRequest request) {
 
         //중첩 람다 -> db 조회 1번
         userRepository.findByAccount(request.getAccount()).
@@ -33,4 +33,8 @@ public class AuthService {
         return jwtUtils.generateToken(request.getAccount());
     }
 
+    public String issueRefreshToken(String refreshToken) {
+
+        return jwtUtils.verifyRefreshTokenAndReissue(refreshToken);
+    }
 }

--- a/src/test/java/com/foodiefinder/auth/controller/AuthControllerTest.java
+++ b/src/test/java/com/foodiefinder/auth/controller/AuthControllerTest.java
@@ -8,6 +8,7 @@ import com.foodiefinder.auth.jwt.JwtUtils;
 import com.foodiefinder.auth.service.AuthService;
 import com.foodiefinder.user.controller.UserController;
 import com.foodiefinder.user.dto.UserSignupRequest;
+import jakarta.servlet.http.Cookie;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -89,4 +90,22 @@ class AuthControllerTest {
                 .andExpect(content().string("user"));
 
     }
+
+    @DisplayName("새로운 액세스 토큰 발급")
+    @WithMockUser
+    @Test
+    void issueRefreshToken() throws Exception{
+
+        String refreshToken = "refresh-token";
+        String newAccessToken = "new-access-token";
+
+        given(authService.issueRefreshToken(refreshToken)).willReturn(newAccessToken);
+
+        mockMvc.perform(post("/api/users/refresh").with(csrf())
+                    .cookie(new Cookie("Bearer", refreshToken)))
+                .andDo(print())
+                .andExpect(status().isOk())
+                .andExpect(content().json("{\"Bearer\":\"new-access-token\"}"));
+    }
+
 }

--- a/src/test/java/com/foodiefinder/auth/controller/AuthControllerTest.java
+++ b/src/test/java/com/foodiefinder/auth/controller/AuthControllerTest.java
@@ -34,8 +34,7 @@ import static org.springframework.security.test.web.servlet.request.SecurityMock
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.*;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
 import static org.springframework.test.web.servlet.result.MockMvcResultHandlers.print;
-import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.content;
-import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.*;
 
 @WebMvcTest(controllers = AuthController.class,
         excludeFilters = {
@@ -64,14 +63,17 @@ class AuthControllerTest {
                 .password("password123!!")
                 .build();
 
-        given(authService.login(any(UserLoginRequest.class))).willReturn("mocked-token");
+        String[] returnData = new String[]{"access-token", "refresh-token"};
+
+        given(authService.login(any(UserLoginRequest.class))).willReturn(returnData);
 
         mockMvc.perform(post("/api/users/login").with(csrf())
                 .contentType(MediaType.APPLICATION_JSON)
                 .content(objectMapper.writeValueAsString(request)))
                 .andDo(print())
                 .andExpect(status().isOk())
-                .andExpect(content().json("{\"token\":\"mocked-token\"}"));
+                .andExpect(content().json("{\"Bearer\":\"access-token\"}")) //응답 액세스토큰
+                .andExpect(cookie().value("Bearer", "refresh-token")); //쿠키 리프레시토큰
     }
 
     @DisplayName("인증, 인가가 필요한 URL 테스트")
@@ -85,5 +87,6 @@ class AuthControllerTest {
                 .andDo(print())
                 .andExpect(status().isOk())
                 .andExpect(content().string("user"));
+
     }
 }

--- a/src/test/java/com/foodiefinder/auth/service/AuthServiceTest.java
+++ b/src/test/java/com/foodiefinder/auth/service/AuthServiceTest.java
@@ -107,4 +107,18 @@ class AuthServiceTest {
         //then
         assertThrows(CustomException.class, () -> authService.login(request));
     }
+
+    @DisplayName("토큰 재발급")
+    @Test
+    void issueNewAccessToken() {
+
+        String refreshToken = "refresh-token";
+        String newAccessToken = "new-access-token";
+
+        when(jwtUtils.verifyRefreshTokenAndReissue(refreshToken)).thenReturn(newAccessToken);
+
+        String result = authService.issueRefreshToken(refreshToken);
+
+        assertEquals(newAccessToken, result);
+    }
 }

--- a/src/test/java/com/foodiefinder/auth/service/AuthServiceTest.java
+++ b/src/test/java/com/foodiefinder/auth/service/AuthServiceTest.java
@@ -11,14 +11,11 @@ import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.InjectMocks;
 import org.mockito.Mock;
-import org.mockito.Spy;
 import org.mockito.junit.jupiter.MockitoExtension;
 
 import java.util.Optional;
 
 import static org.junit.jupiter.api.Assertions.*;
-import static org.mockito.ArgumentMatchers.any;
-import static org.mockito.BDDMockito.given;
 import static org.mockito.Mockito.when;
 
 @ExtendWith(MockitoExtension.class)
@@ -43,7 +40,7 @@ class AuthServiceTest {
         String account = "testAccount";
         String password = "password123";
         String encodedPassword = "encodedPassword123";
-        String token = "mocked-token";
+        String[] tokens = new String[]{"access-token", "refresh-token"};
 
         UserLoginRequest request = UserLoginRequest.builder()
                 .account(account)
@@ -58,13 +55,14 @@ class AuthServiceTest {
         //given
         when(userRepository.findByAccount(account)).thenReturn(Optional.of(user));
         when(passwordEncoder.matches(password, encodedPassword)).thenReturn(true);
-        when(jwtUtils.generateToken(account)).thenReturn(token);
+        when(jwtUtils.generateToken(account)).thenReturn(tokens);
 
         //when
-        String result = authService.login(request);
+        String[] result = authService.login(request);
 
         //then
-        assertEquals(token, result);
+        assertEquals(tokens[0], result[0]);
+        assertEquals(tokens[1], result[1]);
     }
 
     @DisplayName("로그인 시 유저 못찾음")


### PR DESCRIPTION
## 🚀 풀 리퀘스트 요약

- 로그인 시 액세스토큰과 리프레시 토큰을 발급하다보니, properties에 
```
jwt.secret.access.key=123123
jwt.secret.refresh.key=456456
```
위 두가지 넣어야 합니다.
- 로그인 시 액세스 토큰은 응답으로 리프레시 토큰은 cookie로 만들어서 건냅니다.
- 토큰 재발급 api 요청 시에는 넘어오는 쿠키값으로만 검증을 진행한 뒤 유효하다면 다시 액세스 토큰을 응답해줍니다.
- security filter 코드는 변경하지 않고 permitAll로 설정해두었습니다.

`설명이 부족할 수 있는데, 피드백이나 궁금한 점 있으시면 댓글 남겨주세요!`

## 📋 변경 사항

- [x] 새로운 기능 추가
- [ ] 버그 수정
- [ ] 코드에 영향을 주지 않는 변경사항(오타 수정, 탭 사이즈 변경, 변수명 변경 등)
- [x] 코드 리팩토링
- [ ] 주석 추가 및 수정
- [ ] 문서 수정
- [x] 테스트 추가, 테스트 리팩토링
- [ ] 빌드 부분 혹은 패키지 매니저 수정
- [ ] 파일 혹은 폴더명 수정
- [ ] 파일 혹은 폴더 삭제

## 📸 스크린샷

(선택 사항: 변경된 내용을 시각적으로 보여주기 위해 스크린샷을 첨부하세요.)

## 📌 체크리스트

- [x] 커밋 메시지 컨벤션에 맞게 작성했습니다.
- [x] 모든 테스트를 통과합니다.

## 📎 관련 이슈

#58 

## 🙌 리뷰 및 피드백


